### PR TITLE
Add `cli.js` to `files`

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "test": "mocha"
   },
-  "files": [
+  "files": [<% if (cli) { %>
+    "cli.js",<% } %>
     "index.js"
   ],
   "keywords": [<% if (cli) { %>


### PR DESCRIPTION
`cli.js` needs to be added to `files` in `package.json`. I forgot this when adding the CLI boilerplate. Sorry!