### PR TITLE
Do not copy _package.json

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -55,8 +55,13 @@ module.exports = yeoman.generators.Base.extend({
 				this.fs.move(this.destinationPath(from), this.destinationPath(to));
 			}.bind(this);
 
+			var cpTpl = function (from, to) {
+				this.fs.copyTpl(this.templatePath(from), this.destinationPath(to), tpl);
+			}.bind(this);
+
 			this.fs.copyTpl([
 				this.templatePath() + '/**',
+				'!**/_package.json',
 				'!**/cli.js'
 			], this.destinationPath(), tpl);
 
@@ -69,7 +74,7 @@ module.exports = yeoman.generators.Base.extend({
 			mv('gitignore', '.gitignore');
 			mv('jshintrc', '.jshintrc');
 			mv('travis.yml', '.travis.yml');
-			mv('_package.json', 'package.json');
+			cpTpl('_package.json', 'package.json');
 
 			cb();
 		}.bind(this));


### PR DESCRIPTION
> We should store the file as _package.json in our repo, but it should be copied as package.json. The _package.json should never be copied to the user's project.

https://github.com/sindresorhus/generator-nm/issues/17#issuecomment-120394491