### PR TITLE
force removal of `cli.js` if the user answered `No` to CLI question.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -62,7 +62,9 @@ module.exports = yeoman.generators.Base.extend({
 
 			if (props.cli) {
 				this.fs.copyTpl(this.templatePath('cli.js'), this.destinationPath('cli.js'), tpl);
-			}
+			} else if (this.fs.exists(this.destinationPath('cli.js'))) {
+        this.fs.delete(this.destinationPath('cli.js'))
+      }
 
 			mv('editorconfig', '.editorconfig');
 			mv('gitattributes', '.gitattributes');


### PR DESCRIPTION
Technically this should be handled by the ignore pattern `!**/cli.js`, but that fails to work on multiple machines.

This PR comes without tests, but a test for this was already added in @cdd4a7f, and it passes (even though I have demonstrated `cli.js` gets copied regardless of the users answer on multiple platforms).

See #17.
(cherry picked from commit 4fbc76b)