### PR TITLE
Replace `mocha` with `ava` in templates

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -14,7 +14,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && mocha"
+    "test": "xo && ava"
   },
   "files": [
     "index.js"<% if (cli) { %>,
@@ -29,13 +29,12 @@
     "meow": "^3.3.0"
   <% } %>},
   "devDependencies": {
-    "mocha": "^2.2.5",
+    "ava": "^0.2.0",
     "xo": "^0.9.0"
   },
   "xo": {
-    "envs": [
-      "node",
-      "mocha"
+    "ignores": [
+      "test.js"
     ]
   }
 }

--- a/app/templates/test.js
+++ b/app/templates/test.js
@@ -1,7 +1,7 @@
-'use strict';
-var assert = require('assert');
-var <%= camelModuleName %> = require('./');
+import test from 'ava';
+import fn from './';
 
-it('should ', function () {
-	assert.strictEqual(<%= camelModuleName %>('unicorns'), 'unicorns & rainbows');
+test('should ', t => {
+	t.is(fn('unicorns'), 'unicorns & rainbows');
+	t.end();
 });


### PR DESCRIPTION
`ava` has matured greatly lately and should be stable enough to be used instead of `mocha`.

Fixes #4.