### PR TITLE
Add log files to gitignore

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.log


### PR DESCRIPTION
I find that when using npm, ignoring the `npm-debug.log` (or basically any other log files) is a common thing to do. You obviously do not want logs to be present in the repo.