### PR TITLE
Fix Deprecated API References

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -5,7 +5,7 @@ const humanizeUrl = require('humanize-url');
 const yeoman = require('yeoman-generator');
 const _s = require('underscore.string');
 
-module.exports = yeoman.generators.Base.extend({
+module.exports = yeoman.Base.extend({
 	init() {
 		const cb = this.async();
 		const self = this;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "ava": "*",
     "pify": "^2.2.0",
     "xo": "*",
-    "yeoman-assert": "^2.0.0"
+    "yeoman-assert": "^2.0.0",
+    "yeoman-test": "^1.0.0"
   },
   "xo": {
     "esnext": true,

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import test from 'ava';
-import {test as helpers} from 'yeoman-generator';
+import helpers from 'yeoman-test';
 import assert from 'yeoman-assert';
 import pify from 'pify';
 


### PR DESCRIPTION
The generator was throwing a warning: `(!) require('yeoman-generator').generators.Base is deprecated. Use require('yeoman-generator').Base directly`.

The tests was throwing a warning: `(!) yeoman.test is deprecated. Instead require('yeoman-test').`

Lastly, Merry Xmas!