### PR TITLE
Add coveralls support.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -36,6 +36,12 @@ module.exports = yeoman.Base.extend({
 			message: 'Do you need code coverage?',
 			type: 'confirm',
 			default: false
+		}, {
+			name: 'coveralls',
+			message: 'Upload coverage to coveralls.io?',
+			type: 'confirm',
+			default: false,
+			when: x => x.nyc
 		}], props => {
 			const tpl = {
 				moduleName: props.moduleName,
@@ -47,7 +53,8 @@ module.exports = yeoman.Base.extend({
 				humanizedWebsite: humanizeUrl(props.website),
 				superb: superb(),
 				cli: props.cli,
-				nyc: props.nyc
+				nyc: props.nyc,
+				coveralls: props.coveralls
 			};
 
 			const mv = (from, to) => {

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -14,7 +14,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && <% if (nyc) { %>nyc <% } %>ava"
+    "test": "xo && <% if (nyc) { %>nyc <% if (coveralls) { %>--reporter=lcov --reporter=text <% } %><% } %>ava"
   },
   "files": [
     "index.js"<% if (cli) { %>,
@@ -29,8 +29,9 @@
     "meow": "^3.7.0"
   <% } %>},
   "devDependencies": {
-    "ava": "^0.14.0",
-    "xo": "^0.14.0"<% if (nyc) { %>,
-    "nyc": "^6.4.0"<% } %>
+    "ava": "^0.14.0",<% if (coveralls) { %>
+    "coveralls": "^2.11.9",<% } %><% if (nyc) { %>
+    "nyc": "^6.4.0",<% } %>
+    "xo": "^0.14.0"
   }
 }

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -14,8 +14,14 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && <% if (nyc) { %>nyc <% if (coveralls) { %>--reporter=lcov --reporter=text <% } %><% } %>ava"
-  },
+    "test": "xo && <% if (nyc) { %>nyc <% } %>ava"
+  },<% if (coveralls) { %>
+  "nyc": {
+    "reporter": [
+      "lcov",
+      "text"
+    ]
+  },<% } %>
   "files": [
     "index.js"<% if (cli) { %>,
     "cli.js"<% } %>

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,13 +15,7 @@
   },
   "scripts": {
     "test": "xo && <% if (nyc) { %>nyc <% } %>ava"
-  },<% if (coveralls) { %>
-  "nyc": {
-    "reporter": [
-      "lcov",
-      "text"
-    ]
-  },<% } %>
+  },
   "files": [
     "index.js"<% if (cli) { %>,
     "cli.js"<% } %>
@@ -39,5 +33,11 @@
     "coveralls": "^2.11.9",<% } %><% if (nyc) { %>
     "nyc": "^6.4.0",<% } %>
     "xo": "^0.14.0"
-  }
+  }<% if (coveralls) { %>,
+  "nyc": {
+    "reporter": [
+      "lcov",
+      "text"
+    ]
+  }<% } %>
 }

--- a/app/templates/readme.md
+++ b/app/templates/readme.md
@@ -1,4 +1,4 @@
-# <%= moduleName %> [![Build Status](https://travis-ci.org/<%= githubUsername %>/<%= moduleName %>.svg?branch=master)](https://travis-ci.org/<%= githubUsername %>/<%= moduleName %>)
+# <%= moduleName %> [![Build Status](https://travis-ci.org/<%= githubUsername %>/<%= moduleName %>.svg?branch=master)](https://travis-ci.org/<%= githubUsername %>/<%= moduleName %>)<% if (coveralls) { %> [![Coverage Status](https://coveralls.io/repos/github/<%= githubUsername %>/<%= moduleName %>/badge.svg?branch=master)](https://coveralls.io/github/<%= githubUsername %>/<%= moduleName %>?branch=master)<% } %>
 
 > My <%= superb %> module
 

--- a/app/templates/travis.yml
+++ b/app/templates/travis.yml
@@ -5,5 +5,5 @@ node_js:
   - '0.12'
   - '0.10'
 <% if (coveralls) { %>after_script:
-  - 'cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js'
+  - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls.js'
 <% } %>

--- a/app/templates/travis.yml
+++ b/app/templates/travis.yml
@@ -4,3 +4,6 @@ node_js:
   - '4'
   - '0.12'
   - '0.10'
+<% if (coveralls) { %>after_script:
+  - 'cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js'
+<% } %>

--- a/app/templates/travis.yml
+++ b/app/templates/travis.yml
@@ -5,5 +5,5 @@ node_js:
   - '0.12'
   - '0.10'
 <% if (coveralls) { %>after_script:
-  - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls.js'
+  - 'cat coverage/lcov.info | ./node_modules/.bin/coveralls.js'
 <% } %>

--- a/test.js
+++ b/test.js
@@ -59,7 +59,8 @@ test.serial('nyc option', async () => {
 		githubUsername: 'test',
 		website: 'test.com',
 		cli: false,
-		nyc: true
+		nyc: true,
+		coveralls: false
 	});
 
 	await pify(generator.run.bind(generator))();
@@ -69,4 +70,27 @@ test.serial('nyc option', async () => {
 	assert.fileContent('.gitignore', /coverage/);
 	assert.fileContent('package.json', /"xo && nyc ava"/);
 	assert.fileContent('package.json', /"nyc":/);
+	assert.noFileContent('package.json', /"coveralls":/);
+	assert.noFileContent('.travis.yml', /coveralls/);
+});
+
+test.serial('coveralls option', async () => {
+	helpers.mockPrompt(generator, {
+		moduleName: 'test',
+		githubUsername: 'test',
+		website: 'test.com',
+		cli: false,
+		nyc: true,
+		coveralls: true
+	});
+
+	await pify(generator.run.bind(generator))();
+
+	assert.noFile('cli.js');
+	assert.fileContent('.gitignore', /\.nyc_output/);
+	assert.fileContent('.gitignore', /coverage/);
+	assert.fileContent('package.json', /"xo && nyc --reporter=lcov --reporter=text ava"/);
+	assert.fileContent('package.json', /"nyc":/);
+	assert.fileContent('package.json', /"coveralls":/);
+	assert.fileContent('.travis.yml', /coveralls/);
 });

--- a/test.js
+++ b/test.js
@@ -69,8 +69,9 @@ test.serial('nyc option', async () => {
 	assert.fileContent('.gitignore', /\.nyc_output/);
 	assert.fileContent('.gitignore', /coverage/);
 	assert.fileContent('package.json', /"xo && nyc ava"/);
-	assert.fileContent('package.json', /"nyc":/);
+	assert.fileContent('package.json', /"nyc": "/);
 	assert.noFileContent('package.json', /"coveralls":/);
+	assert.noFileContent('package.json', /"lcov"/);
 	assert.noFileContent('.travis.yml', /coveralls/);
 });
 
@@ -89,8 +90,9 @@ test.serial('coveralls option', async () => {
 	assert.noFile('cli.js');
 	assert.fileContent('.gitignore', /\.nyc_output/);
 	assert.fileContent('.gitignore', /coverage/);
-	assert.fileContent('package.json', /"xo && nyc --reporter=lcov --reporter=text ava"/);
-	assert.fileContent('package.json', /"nyc":/);
+	assert.fileContent('package.json', /"xo && nyc ava"/);
+	assert.fileContent('package.json', /"nyc": "/);
 	assert.fileContent('package.json', /"coveralls":/);
+	assert.fileContent('package.json', /"lcov"/);
 	assert.fileContent('.travis.yml', /coveralls/);
 });


### PR DESCRIPTION
If the user replies "yes" to the coverage question, they will be asked if they wish to add coveralls support.

If they reply "yes", the following additions are made:

- `coveralls` is added as a devDependency
- The test script is modified to be: `xo && nyc --reporter=text --reporter=lcov ava`. This generates lcov data during the test run.
- An `after_script:` section is added to `.travis.yml` which uploads the generated lcov data to coveralls.
- A coveralls badge is added to the readme.