### PR TITLE
Add some CLI options.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,26 @@ With [yo](https://github.com/yeoman/yo):
 $ yo nm
 ```
 
+There are multiple command line options available:
+
+```
+$ yo nm --help
+Usage:
+  yo nm:app [options]
+
+Options:
+  -h,   --help          # Print the generator's options and usage
+        --skip-cache    # Do not remember prompt answers                      Default: false
+        --skip-install  # Do not automatically install dependencies           Default: false
+        --org           # Publish to a GitHub organization account
+        --cli           # Add a CLI
+        --coverage      # Add code coverage with nyc
+        --coveralls     # Upload coverage to coveralls.io (implies coverage)
+```
+
+The `--org` option takes a string value (i.e. `--org=avajs`), all others are boolean flags and can be negated with the `no` prefix (i.e. `--no-coveralls`)
+
+You will be prompted for any options not passed on the command line.
 
 ## Tip
 


### PR DESCRIPTION
My main concern was allowing me to set it up for publishing to an organisation, without overwriting my default answer for username.

I've also added options for CLI support, coverage, and coveralls.

There are no tests associated with this, only because I don't know how to test CLI options (if someone points me in the right direction, I will add tests). It would be good to be able to test *if* a question got asked (not sure if that is possible), since there is now some logic in the `when` conditions.

Finally, the use of `self` is not needed with arrow functions, `this` is bound to the surrounding scope. So I deleted all `self` references in favor of `this`.