### PR TITLE
Add `throw TypeError` test

### DIFF
--- a/app/templates/test.js
+++ b/app/templates/test.js
@@ -2,7 +2,8 @@ import test from 'ava';
 import fn from './';
 
 test('title', t => {
-	t.is(fn('unicorns'), 'unicorns & rainbows');
 	const err = t.throws(() => fn(123), TypeError);
 	t.is(err.message, 'Expected a string, got number');
+	
+	t.is(fn('unicorns'), 'unicorns & rainbows');
 });

--- a/app/templates/test.js
+++ b/app/templates/test.js
@@ -3,4 +3,6 @@ import fn from './';
 
 test('title', t => {
 	t.is(fn('unicorns'), 'unicorns & rainbows');
+	const err = t.throws(() => fn(123), TypeError);
+	t.is(err.message, 'Expected a string, got number');
 });


### PR DESCRIPTION
Illustrates AVA error testing for beginners. Also bumps NYC coverage to 100%.