### PR TITLE
add `preferGlobal` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Scaffold out a node module",
   "license": "MIT",
   "repository": "sindresorhus/generator-nm",
+  "preferGlobal": true,
   "author": {
     "name": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",


### PR DESCRIPTION
A yeoman generator is supposed to be installed globally.
So by setting `preferGlobal: true` will make the installation instruction
on npmjs.com matches that intention.

it'll be written as `npm install -g generator-nm`
instead of `npm install generator-nm`